### PR TITLE
[core] update for latest OR/OBSE compatibility and other improvements

### DIFF
--- a/ConfigFile.cpp
+++ b/ConfigFile.cpp
@@ -79,7 +79,12 @@ void ConfigFile::InitImpl()
 	if (m_Initialized) return;
 	m_Initialized = true;
 
+#ifdef ASI
+	const string fullPath = GetPluginDirectory() + "\\DeleteSpells.conf";
+#else
 	const string fullPath = GetPluginDirectory() + "\\OBSE\\Plugins\\DeleteSpells.conf";
+#endif
+
 	LoadFromFile(fullPath);
 }
 

--- a/ConfigFile.cpp
+++ b/ConfigFile.cpp
@@ -1,0 +1,204 @@
+#include "pch.h"
+#include "ConfigFile.h"
+
+#include <fstream>
+#include <sstream>
+#include <filesystem>
+#include <Windows.h>
+#include <cctype>
+#include <cstdio>
+
+using namespace std;
+
+ConfigFile& ConfigFile::GetInstance()
+{
+	static ConfigFile instance;
+	return instance;
+}
+
+void ConfigFile::Init()
+{
+	GetInstance().InitImpl();
+}
+
+bool ConfigFile::GetBool(std::string_view key, bool defaultValue)
+{
+	auto& self = GetInstance();
+	if (!self.m_Initialized) self.InitImpl();
+
+	auto it = self.m_Variables.find(std::string(key));
+	if (it == self.m_Variables.end()) return defaultValue;
+
+	std::string val = self.Trim(it->second);
+	for (char& c : val) c = (char)tolower(c);
+
+	bool result = (val == "true" || val == "1");
+	LogReadResult<bool>(std::string(key), result, defaultValue);
+	return result;
+}
+
+int ConfigFile::GetInt(std::string_view key, int defaultValue)
+{
+	auto& self = GetInstance();
+	if (!self.m_Initialized) self.InitImpl();
+
+	auto it = self.m_Variables.find(std::string(key));
+	if (it == self.m_Variables.end()) return defaultValue;
+
+	int result = 0;
+	std::istringstream iss(it->second);
+	bool parsed = (iss >> result).get();
+	LogReadResult<int>(std::string(key), parsed ? std::optional(result) : std::nullopt, defaultValue);
+	return parsed ? result : defaultValue;
+}
+
+float ConfigFile::GetFloat(std::string_view key, float defaultValue)
+{
+	auto& self = GetInstance();
+	if (!self.m_Initialized) self.InitImpl();
+
+	auto it = self.m_Variables.find(std::string(key));
+	if (it == self.m_Variables.end()) return defaultValue;
+
+	float result = 0;
+	std::istringstream iss(it->second);
+	bool parsed = (iss >> result).get();
+	LogReadResult<float>(std::string(key), parsed ? std::optional(result) : std::nullopt, defaultValue);
+	return parsed ? result : defaultValue;
+}
+
+const std::unordered_set<uint32_t>& ConfigFile::GetBlacklistedSpells()
+{
+	auto& self = GetInstance();
+	if (!self.m_Initialized) self.InitImpl();
+	return self.m_BlacklistedFormIDs;
+}
+
+void ConfigFile::InitImpl()
+{
+	if (m_Initialized) return;
+	m_Initialized = true;
+
+	const string fullPath = GetPluginDirectory() + "\\OBSE\\Plugins\\DeleteSpells.conf";
+	LoadFromFile(fullPath);
+}
+
+void ConfigFile::LoadFromFile(const std::string& fullPath)
+{
+	std::ifstream file(fullPath);
+	if (!file.is_open()) {
+		printf("[Delete Spells] Config not found, generating default...\n");
+		if (!GenerateDefault(fullPath)) {
+			printf("[Delete Spells] Failed to generate config file\n");
+			return;
+		}
+		file.open(fullPath);
+	}
+	if (!file.is_open()) return;
+
+	enum class ParseState { None, InArray };
+	ParseState state = ParseState::None;
+	std::string currentArrayName;
+	std::string line;
+	size_t lineNum = 0;
+
+	while (std::getline(file, line)) {
+		lineNum++;
+
+		// Remove comment
+		const auto commentPos = line.find(';');
+		if (commentPos != std::string::npos) line = line.substr(0, commentPos);
+
+		line = Trim(line);
+		if (line.empty()) continue;
+
+		// Open array block, e.g. IgnoreSpells = {
+		const auto eqPos = line.find('=');
+		if (eqPos != std::string::npos && line.find('{', eqPos) != std::string::npos) {
+			currentArrayName = Trim(line.substr(0, eqPos));
+			state = ParseState::InArray;
+			continue;
+		}
+
+		// Close array
+		if (line == "}") {
+			state = ParseState::None;
+			currentArrayName.clear();
+			continue;
+		}
+
+		if (state == ParseState::InArray) {
+			if (currentArrayName == "BlacklistedSpells") {
+				uint32_t formID = 0;
+				if (ParseHexFormID(line, formID)) {
+					m_BlacklistedFormIDs.insert(formID);
+				}
+				else {
+					printf("[Delete Spells] Invalid FormID at line %zu: %s\n", lineNum, line.c_str());
+				}
+			}
+			continue;
+		}
+
+		// Key-value assignment
+		if (eqPos != std::string::npos) {
+			const std::string key = Trim(line.substr(0, eqPos));
+			const std::string value = Trim(line.substr(eqPos + 1));
+			m_Variables[key] = value;
+		}
+		else {
+			printf("[Delete Spells] Invalid line at %zu: %s\n", lineNum, line.c_str());
+		}
+	}
+
+	printf("[Delete Spells] Loaded %zu variables, %zu blacklisted spells\n",
+		m_Variables.size(), 
+		m_BlacklistedFormIDs.size());
+}
+
+bool ConfigFile::GenerateDefault(const string& path)
+{
+	ofstream out(path);
+	if (!out.is_open()) return false;
+
+	out << "; === ConfigFile ===\n";
+	out << "bProtectSpells = true\n";
+	out << "bSpellInfoLog = false\n";
+	out << "\n";
+	out << "; === Blacklist ===\n";
+	out << "BlacklistedSpells = {\n";
+	out << "    0x00000136 ; Heal Minor Wounds\n";
+	out << "}\n";
+
+	out.close();
+	printf("[Delete Spells] Default config generated at: %s\n", path.c_str());
+	return true;
+}
+
+bool ConfigFile::ParseHexFormID(const std::string& value, uint32_t& out)
+{
+	std::string trimmed = Trim(value);
+	if (trimmed.starts_with("0x") || trimmed.starts_with("0X"))
+		trimmed = trimmed.substr(2);
+	std::istringstream iss(trimmed);
+	iss >> std::hex >> out;
+	return !iss.fail();
+}
+
+std::string ConfigFile::Trim(const std::string& str)
+{
+	const auto first = str.find_first_not_of(" \t\r\n");
+	if (first == string::npos) return "";
+	const auto last = str.find_last_not_of(" \t\r\n");
+	return str.substr(first, last - first + 1);
+}
+
+std::string ConfigFile::GetPluginDirectory()
+{
+	HMODULE hModule = nullptr;
+	GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, nullptr, &hModule);
+
+	char path[MAX_PATH] = {};
+	GetModuleFileNameA(hModule, path, MAX_PATH);
+	return std::filesystem::path(path).parent_path().string();
+}

--- a/ConfigFile.cpp
+++ b/ConfigFile.cpp
@@ -180,7 +180,7 @@ bool ConfigFile::GenerateDefault(const string& path)
 	out << "bSpellInfoLog = false ; If true, spell information will be logged to the console\n";
 	out << "\n";
 	out << "; === Keyboard ===\n";
-	out << "iKeyboardDeleteKey = 0x45 ; Default is VK_E\n";
+	out << "; Valid modifier keys: 0xA0 (VK_LSHIFT), 0xA1 (VK_RSHIFT), 0xA2 (VK_LCONTROL), 0xA3 (VK_RCONTROL), 0xA4 (VK_LMENU), 0xA5 (VK_RMENU)\n";
 	out << "iKeyboardModifierKey = 0xA0 ; Default is VK_LSHIFT\n";
 	out << "\n";
 	out << "; === Gamepad ===\n";

--- a/ConfigFile.cpp
+++ b/ConfigFile.cpp
@@ -177,6 +177,7 @@ bool ConfigFile::GenerateDefault(const string& path)
 
 	out << "; === ConfigFile ===\n";
 	out << "bProtectSpells = true ; If true, spells in the blacklist will not be deleted\n";
+	out << "bUseTranslationFile = true ; If true, uses translated confirmation string from Magic Loader 2 json file, otherwise uses hardcoded English version\n";
 	out << "bSpellInfoLog = false ; If true, spell information will be logged to the console\n";
 	out << "\n";
 	out << "; === Keyboard ===\n";

--- a/ConfigFile.cpp
+++ b/ConfigFile.cpp
@@ -45,9 +45,18 @@ int ConfigFile::GetInt(std::string_view key, int defaultValue)
 	auto it = self.m_Variables.find(std::string(key));
 	if (it == self.m_Variables.end()) return defaultValue;
 
+    std::string val = self.Trim(it->second);
 	int result = 0;
-	std::istringstream iss(it->second);
-	bool parsed = (iss >> result).get();
+
+	std::istringstream iss(val);
+
+	// Check if the value starts with "0x" or "0X" for hex parsing
+	if (val.starts_with("0x") || val.starts_with("0X"))
+		iss >> std::hex >> result;
+	else
+		iss >> result;
+
+	bool parsed = !iss.fail();
 	LogReadResult<int>(std::string(key), parsed ? std::optional(result) : std::nullopt, defaultValue);
 	return parsed ? result : defaultValue;
 }
@@ -167,8 +176,17 @@ bool ConfigFile::GenerateDefault(const string& path)
 	if (!out.is_open()) return false;
 
 	out << "; === ConfigFile ===\n";
-	out << "bProtectSpells = true\n";
-	out << "bSpellInfoLog = false\n";
+	out << "bProtectSpells = true ; If true, spells in the blacklist will not be deleted\n";
+	out << "bSpellInfoLog = false ; If true, spell information will be logged to the console\n";
+	out << "\n";
+	out << "; === Keyboard ===\n";
+	out << "iKeyboardDeleteKey = 0x45 ; Default is VK_E\n";
+	out << "iKeyboardModifierKey = 0xA0 ; Default is VK_LSHIFT\n";
+	out << "\n";
+	out << "; === Gamepad ===\n";
+	out << "bGamepadSupport = true ; If true, allows gamepad combo to trigger deletion\n";
+	out << "iGamepadDeleteButton = 0x1000 ; Default is XINPUT_GAMEPAD_A\n";
+	out << "iGamepadModifierButton = 0x0020 ; Default is XINPUT_GAMEPAD_BACK\n";
 	out << "\n";
 	out << "; === Blacklist ===\n";
 	out << "BlacklistedSpells = {\n";

--- a/ConfigFile.h
+++ b/ConfigFile.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <string_view>
+#include <cstdint>
+#include <optional>
+
+class ConfigFile
+{
+public:
+	static void Init(); // ручной вызов, если нужно
+	static bool GetBool(std::string_view key, bool defaultValue = false);
+	static int GetInt(std::string_view key, int defaultValue = 0);
+	static float GetFloat(std::string_view key, float defaultValue = 0.0f);
+
+	static const std::unordered_set<uint32_t>& GetBlacklistedSpells();
+
+private:
+	static ConfigFile& GetInstance();
+
+	void InitImpl();
+	void LoadFromFile(const std::string& fullPath);
+	bool GenerateDefault(const std::string& path);
+
+	bool ParseHexFormID(const std::string& value, uint32_t& out);
+	std::string Trim(const std::string& str);
+	std::string GetPluginDirectory();
+
+	template <typename T>
+	static void LogReadResult(const std::string& key, const std::optional<T>& value, const T& fallback) {
+		auto toString = [](const T& v) -> std::string {
+			if constexpr (std::is_same_v<T, bool>)
+				return v ? "true" : "false";
+			else
+				return std::to_string(v);
+			};
+
+		if (value) {
+			printf("[Delete Spells] Config option: %s = %s\n", key.c_str(), toString(*value).c_str());
+		}
+		else {
+			printf("[Delete Spells] Config option: %s = <default> (%s)\n", key.c_str(), toString(fallback).c_str());
+		}
+	}
+
+private:
+	bool m_Initialized = false;
+	std::unordered_map<std::string, std::string> m_Variables;
+	std::unordered_set<uint32_t> m_BlacklistedFormIDs;
+};

--- a/DeleteSpells.vcxproj
+++ b/DeleteSpells.vcxproj
@@ -279,9 +279,10 @@
       <EnableUAC>false</EnableUAC>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)$(Platform)\$(Configuration)\*" "E:\SteamLibrary\steamapps\common\Oblivion Remastered\OblivionRemastered\Binaries\Win64\obse\plugins"
+      <Command>mkdir "$(SolutionDir)Nexus\OBSE\OblivionRemastered\Binaries\Win64\obse\plugins"
 copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).dll" "$(SolutionDir)Nexus\OBSE\OblivionRemastered\Binaries\Win64\obse\plugins\$(ProjectName).dll"
-copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).pdb" "$(SolutionDir)Nexus\OBSE\OblivionRemastered\Binaries\Win64\obse\plugins\$(ProjectName).pdb"</Command>
+copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).pdb" "$(SolutionDir)Nexus\OBSE\OblivionRemastered\Binaries\Win64\obse\plugins\$(ProjectName).pdb"
+</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release - ASI|x64'">
@@ -307,7 +308,8 @@ copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).pdb" "$(Solution
       <EnableUAC>false</EnableUAC>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).dll" "$(SolutionDir)Nexus\ASI\OblivionRemastered\Binaries\WinGDK\$(ProjectName).asi"
+      <Command>mkdir "$(SolutionDir)Nexus\ASI\OblivionRemastered\Binaries\WinGDK\"
+copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).dll" "$(SolutionDir)Nexus\ASI\OblivionRemastered\Binaries\WinGDK\$(ProjectName).asi"
 copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).pdb" "$(SolutionDir)Nexus\ASI\OblivionRemastered\Binaries\WinGDK\$(ProjectName).pdb"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -338,6 +340,7 @@ copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).pdb" "$(Solution
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="ConfigFile.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="ObSDK\Types\Altar\EVUnpairingState.h" />
     <ClInclude Include="ObSDK\Types\Altar\ExtraDataList.h" />
@@ -431,6 +434,7 @@ copy "$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).pdb" "$(Solution
     <ClInclude Include="PluginAPI.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ConfigFile.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/DeleteSpells.vcxproj.filters
+++ b/DeleteSpells.vcxproj.filters
@@ -288,12 +288,18 @@
     <ClInclude Include="ObSDK\Utils\Signatures.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ConfigFile.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ConfigFile.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -52,6 +52,7 @@ static FnMagicMenu_DoClick		og_MagicMenu_DoClick;
 
 // Config flags
 static bool protectSpells = ConfigFile::GetBool("bProtectSpells", true);
+static bool translationFile = ConfigFile::GetBool("bUseTranslationFile", true);
 static bool spellInfoLog = ConfigFile::GetBool("bSpellInfoLog", false);
 static bool gamepadSupport = ConfigFile::GetBool("bGamepadSupport", true);
 
@@ -225,7 +226,7 @@ static void hk_MagicMenu_DoClick(MagicMenu* menu, int aiID, Tile* apTarget) {
 	selectedItem = curItem;
 
 	Interface_CreateMessageMenu(
-		"LOC_HC_DeleteSpell_Confirm",
+		translationFile ? "LOC_HC_DeleteSpell_Confirm" : "Are you sure you want to delete this spell?",
 		[] {
 			if (GetMessageMenuresult() == 1) {
 				PlayerCharacter::GetSingleton()->RemoveSpell(selectedItem);

--- a/obse64_version.h
+++ b/obse64_version.h
@@ -3,11 +3,14 @@
 
 // these have to be macros so they can be used in the .rc
 #define OBSE_VERSION_INTEGER		0
-#define OBSE_VERSION_INTEGER_MINOR	1
-#define OBSE_VERSION_INTEGER_BETA	0
-#define OBSE_VERSION_VERSTRING		"0, 0, 1, 0"
+#define OBSE_VERSION_INTEGER_MINOR	2
+#define OBSE_VERSION_INTEGER_BETA	2
+#define OBSE_VERSION_VERSTRING		"0, 0, 2, 2"
 #define OBSE_VERSION_PADDEDSTRING	"0001"
 #define OBSE_VERSION_RELEASEIDX		1
+
+// the version of classic OBSE currently implemented
+#define OBSE_VERSION_IMPL_INTEGER	6
 
 //	x-------	major
 //	-xxx----	minor
@@ -30,13 +33,15 @@
 #define RUNTIME_VERSION_0_411_140	MAKE_EXE_VERSION(0, 411, 140)	// 0x019B08C0	initial release
 #define RUNTIME_VERSION_0_411_141	MAKE_EXE_VERSION(0, 411, 141)	// 0x019B08D0	ms store only update
 #define RUNTIME_VERSION_0_411_142	MAKE_EXE_VERSION(0, 411, 142)	// 0x019B08E0	ms store only update
+#define RUNTIME_VERSION_1_511_102	MAKE_EXE_VERSION(1, 511, 102)	// 0x11FF0660	beta patch released to public
+#define RUNTIME_VERSION_1_512_105	MAKE_EXE_VERSION(1, 512, 105)	// 0x12000690	beta patch released to public
 
 #define PACKED_OBSE_VERSION		MAKE_EXE_VERSION(OBSE_VERSION_INTEGER, OBSE_VERSION_INTEGER_MINOR, OBSE_VERSION_INTEGER_BETA)
 
 // information about the state of the game at the time of release
 #define OBSE_TARGETING_BETA_VERSION	0
-#define CURRENT_RELEASE_RUNTIME		RUNTIME_VERSION_0_411_140
-#define CURRENT_RELEASE_OBSE_STR	"0.1.0"
+#define CURRENT_RELEASE_RUNTIME		RUNTIME_VERSION_1_512_105
+#define CURRENT_RELEASE_OBSE_STR	"0.2.2"
 
 #if GET_EXE_VERSION_SUB(RUNTIME_VERSION) == RUNTIME_TYPE_BETHESDA
 #define SAVE_FOLDER_NAME "Oblivion Remastered"


### PR DESCRIPTION
- Updated plugin to support the latest Oblivion Remastered and OBSE build
- Refactored internal structure for compatibility and maintainability
- Implemented config system with:
  - Boolean, integer and float variable parsing
  - FormID-based spell blacklist (BlacklistedSpells block)
  - Spell "Heal Minor Wounds" is blacklisted by default
- Automatically generates a default config if missing or malformed
- Hook logic now respects 'bProtectSpells' and prevents deletion of blacklisted spells
- Added optional logging via 'bSpellInfoLog' for debug or discovery of spell FormIDs
- Slightly improved logging format and value reporting
- Replaced hardcoded confirmation prompt with localization label "LOC_HC_DeleteSpell_Confirm"